### PR TITLE
Added files to integrate UberDDR3 on Vivado IP Catalog

### DIFF
--- a/rtl/ddr3_top.v
+++ b/rtl/ddr3_top.v
@@ -44,6 +44,7 @@ module ddr3_top #(
                    ODELAY_SUPPORTED = 0, //set to 1 when ODELAYE2 is supported
                    SECOND_WISHBONE = 0, //set to 1 if 2nd wishbone for debugging is needed 
                    WB_ERROR = 0, // set to 1 to support Wishbone error (asserts at ECC double bit error)
+                   SKIP_INTERNAL_TEST = 0, // skip built-in self test (would require >2 seconds of internal test right after calibration)
     parameter[1:0] ECC_ENABLE = 0, // set to 1 or 2 to add ECC (1 = Side-band ECC per burst, 2 = Side-band ECC per 8 bursts , 3 = Inline ECC ) 
     parameter[1:0] DIC = 2'b00, //Output Driver Impedance Control (2'b00 = RZQ/6, 2'b01 = RZQ/7, RZQ = 240ohms) (only change when you know what you are doing)
     parameter[2:0] RTT_NOM = 3'b011, //RTT Nominal (3'b000 = disabled, 3'b001 = RZQ/4, 3'b010 = RZQ/2 , 3'b011 = RZQ/6, RZQ = 240ohms)  (only change when you know what you are doing)
@@ -104,12 +105,14 @@ module ddr3_top #(
         output wire[BYTE_LANES-1:0] o_ddr3_dm,
         output wire o_ddr3_odt, // on-die termination
         //
+        // Done Calibration pin
+        output wire o_calib_complete,
         // Debug outputs
-        output wire[31:0] o_debug1,
-        output wire[31:0] o_debug2,
-        output wire[31:0] o_debug3,
-        output wire[(DQ_BITS*BYTE_LANES)/8-1:0] o_ddr3_debug_read_dqs_p,
-        output wire[(DQ_BITS*BYTE_LANES)/8-1:0] o_ddr3_debug_read_dqs_n
+        output wire[31:0] o_debug1
+//        output wire[31:0] o_debug2,
+//        output wire[31:0] o_debug3,
+//        output wire[(DQ_BITS*BYTE_LANES)/8-1:0] o_ddr3_debug_read_dqs_p,
+//        output wire[(DQ_BITS*BYTE_LANES)/8-1:0] o_ddr3_debug_read_dqs_n
     );
     
 // Instantiation Template (DEFAULT VALUE IS FOR ARTY S7)
@@ -182,10 +185,6 @@ ddr3_top #(
         .o_ddr3_odt(ddr3_odt),
         // Debug outputs
         .o_debug1(),
-        .o_debug2(),
-        .o_debug3(),
-        .o_ddr3_debug_read_dqs_p(),
-        .o_ddr3_debug_read_dqs_n()
         ////////////////////////////////////
     );
 */
@@ -225,6 +224,7 @@ ddr3_top #(
             .SECOND_WISHBONE(SECOND_WISHBONE), //set to 1 if 2nd wishbone is needed 
             .ECC_ENABLE(ECC_ENABLE), // set to 1 or 2 to add ECC (1 = Side-band ECC per burst, 2 = Side-band ECC per 8 bursts , 3 = Inline ECC ) 
             .WB_ERROR(WB_ERROR), // set to 1 to support Wishbone error (asserts at ECC double bit error)
+            .SKIP_INTERNAL_TEST(SKIP_INTERNAL_TEST), // skip built-in self test (would require >2 seconds of internal test right after calibration)
             .DIC(DIC), //Output Driver Impedance Control (2'b00 = RZQ/6, 2'b01 = RZQ/7, RZQ = 240ohms)
             .RTT_NOM(RTT_NOM) //RTT Nominal (3'b000 = disabled, 3'b001 = RZQ/4, 3'b010 = RZQ/2 , 3'b011 = RZQ/6, RZQ = 240ohms)
         ) ddr3_controller_inst (
@@ -278,10 +278,12 @@ ddr3_top #(
             .o_phy_bitslip(bitslip),
             .o_phy_write_leveling_calib(write_leveling_calib),
             .o_phy_reset(reset),
+            // Done Calibration pin
+            .o_calib_complete(o_calib_complete),
             // Debug outputs
-            .o_debug1(o_debug1),
-            .o_debug2(o_debug2),
-            .o_debug3(o_debug3)
+            .o_debug1(o_debug1)
+//            .o_debug2(o_debug2),
+//            .o_debug3(o_debug3)
         );
         
     ddr3_phy #(
@@ -336,8 +338,8 @@ ddr3_top #(
             .io_ddr3_dqs_n(io_ddr3_dqs_n),
             .o_ddr3_dm(o_ddr3_dm),
             .o_ddr3_odt(o_ddr3_odt), // on-die termination
-            .o_ddr3_debug_read_dqs_p(o_ddr3_debug_read_dqs_p),
-            .o_ddr3_debug_read_dqs_n(o_ddr3_debug_read_dqs_n)
+            .o_ddr3_debug_read_dqs_p(/*o_ddr3_debug_read_dqs_p*/),
+            .o_ddr3_debug_read_dqs_n(/*o_ddr3_debug_read_dqs_n*/)
         );
         
 endmodule

--- a/vivado_custom_ip/component.xml
+++ b/vivado_custom_ip/component.xml
@@ -1,0 +1,2109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<spirit:component xmlns:xilinx="http://www.xilinx.com" xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <spirit:vendor>OpenIPHub</spirit:vendor>
+  <spirit:library>DDR3_Memory_Controller</spirit:library>
+  <spirit:name>uberddr3_axi</spirit:name>
+  <spirit:version>1.0</spirit:version>
+  <spirit:busInterfaces>
+    <spirit:busInterface>
+      <spirit:name>s_axi</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="aximm" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="aximm_rtl" spirit:version="1.0"/>
+      <spirit:slave>
+        <spirit:memoryMapRef spirit:memoryMapRef="s_axi"/>
+      </spirit:slave>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWADDR</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awaddr</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWLEN</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awlen</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWSIZE</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awsize</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWBURST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awburst</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWLOCK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awlock</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWCACHE</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awcache</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWPROT</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awprot</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWQOS</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awqos</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>AWREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_awready</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WDATA</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_wdata</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WSTRB</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_wstrb</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WLAST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_wlast</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_wvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_wready</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>BID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_bid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>BRESP</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_bresp</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>BVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_bvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>BREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_bready</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARADDR</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_araddr</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARLEN</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arlen</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARSIZE</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arsize</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARBURST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arburst</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARLOCK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arlock</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARCACHE</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arcache</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARPROT</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arprot</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARQOS</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arqos</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ARREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_arready</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RDATA</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rdata</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RRESP</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rresp</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RLAST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rlast</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RVALID</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rvalid</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RREADY</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>s_axi_rready</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>i_rst_n</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="reset" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="reset_rtl" spirit:version="1.0"/>
+      <spirit:slave/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RST</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>i_rst_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+      <spirit:parameters>
+        <spirit:parameter>
+          <spirit:name>POLARITY</spirit:name>
+          <spirit:value spirit:id="BUSIFPARAM_VALUE.I_RST_N.POLARITY" spirit:choiceRef="choice_list_9d8b0d81">ACTIVE_LOW</spirit:value>
+        </spirit:parameter>
+      </spirit:parameters>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>i_controller_clk</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock_rtl" spirit:version="1.0"/>
+      <spirit:slave/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CLK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>i_controller_clk</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+      <spirit:parameters>
+        <spirit:parameter>
+          <spirit:name>ASSOCIATED_BUSIF</spirit:name>
+          <spirit:value spirit:id="BUSIFPARAM_VALUE.I_CONTROLLER_CLK.ASSOCIATED_BUSIF">s_axi</spirit:value>
+        </spirit:parameter>
+      </spirit:parameters>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>i_ddr3_clk</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock_rtl" spirit:version="1.0"/>
+      <spirit:slave/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CLK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>i_ddr3_clk</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>i_ref_clk</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock_rtl" spirit:version="1.0"/>
+      <spirit:slave/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CLK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>i_ref_clk</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>ddr3</spirit:name>
+      <spirit:displayName>ddr3</spirit:displayName>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="ddrx" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="interface" spirit:name="ddrx_rtl" spirit:version="1.0"/>
+      <spirit:master/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CS_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_cs_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CK_P</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_clk_p</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CK_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_clk_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>DM</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_dm</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CAS_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_cas_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>DQ</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>io_ddr3_dq</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ADDR</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_addr</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>DQS_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>io_ddr3_dqs_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RAS_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_ras_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>RESET_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_reset_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>DQS_P</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>io_ddr3_dqs</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>WE_N</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_we_n</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CKE</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_cke</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>ODT</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_odt</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>BA</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>o_ddr3_ba_addr</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+    <spirit:busInterface>
+      <spirit:name>i_ddr3_clk_90</spirit:name>
+      <spirit:busType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock" spirit:version="1.0"/>
+      <spirit:abstractionType spirit:vendor="xilinx.com" spirit:library="signal" spirit:name="clock_rtl" spirit:version="1.0"/>
+      <spirit:slave/>
+      <spirit:portMaps>
+        <spirit:portMap>
+          <spirit:logicalPort>
+            <spirit:name>CLK</spirit:name>
+          </spirit:logicalPort>
+          <spirit:physicalPort>
+            <spirit:name>i_ddr3_clk_90</spirit:name>
+          </spirit:physicalPort>
+        </spirit:portMap>
+      </spirit:portMaps>
+    </spirit:busInterface>
+  </spirit:busInterfaces>
+  <spirit:memoryMaps>
+    <spirit:memoryMap>
+      <spirit:name>s_axi</spirit:name>
+      <spirit:displayName>s_axi</spirit:displayName>
+      <spirit:addressBlock>
+        <spirit:name>ddr3_mem</spirit:name>
+        <spirit:displayName>ddr3_mem</spirit:displayName>
+        <spirit:baseAddress spirit:format="bitString" spirit:bitStringLength="1">0x0</spirit:baseAddress>
+        <spirit:range spirit:format="long" spirit:resolve="dependent" spirit:dependency="pow(2,(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ADDR_WIDTH&apos;)) - 1) - 0 + 1)" spirit:minimum="4096" spirit:rangeType="long">268435456</spirit:range>
+        <spirit:width spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_DATA_WIDTH&apos;)) - 1) - 0 + 1">128</spirit:width>
+        <spirit:usage>memory</spirit:usage>
+      </spirit:addressBlock>
+    </spirit:memoryMap>
+  </spirit:memoryMaps>
+  <spirit:model>
+    <spirit:views>
+      <spirit:view>
+        <spirit:name>xilinx_anylanguagesynthesis</spirit:name>
+        <spirit:displayName>Synthesis</spirit:displayName>
+        <spirit:envIdentifier>:vivado.xilinx.com:synthesis</spirit:envIdentifier>
+        <spirit:language>SystemVerilog</spirit:language>
+        <spirit:modelName>ddr3_top_axi</spirit:modelName>
+        <spirit:fileSetRef>
+          <spirit:localName>xilinx_anylanguagesynthesis_view_fileset</spirit:localName>
+        </spirit:fileSetRef>
+        <spirit:parameters>
+          <spirit:parameter>
+            <spirit:name>viewChecksum</spirit:name>
+            <spirit:value>e9f63973</spirit:value>
+          </spirit:parameter>
+        </spirit:parameters>
+      </spirit:view>
+      <spirit:view>
+        <spirit:name>xilinx_anylanguagebehavioralsimulation</spirit:name>
+        <spirit:displayName>Simulation</spirit:displayName>
+        <spirit:envIdentifier>:vivado.xilinx.com:simulation</spirit:envIdentifier>
+        <spirit:language>SystemVerilog</spirit:language>
+        <spirit:modelName>ddr3_top_axi</spirit:modelName>
+        <spirit:fileSetRef>
+          <spirit:localName>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:localName>
+        </spirit:fileSetRef>
+        <spirit:parameters>
+          <spirit:parameter>
+            <spirit:name>viewChecksum</spirit:name>
+            <spirit:value>e9f63973</spirit:value>
+          </spirit:parameter>
+        </spirit:parameters>
+      </spirit:view>
+      <spirit:view>
+        <spirit:name>xilinx_xpgui</spirit:name>
+        <spirit:displayName>UI Layout</spirit:displayName>
+        <spirit:envIdentifier>:vivado.xilinx.com:xgui.ui</spirit:envIdentifier>
+        <spirit:fileSetRef>
+          <spirit:localName>xilinx_xpgui_view_fileset</spirit:localName>
+        </spirit:fileSetRef>
+        <spirit:parameters>
+          <spirit:parameter>
+            <spirit:name>viewChecksum</spirit:name>
+            <spirit:value>30e22270</spirit:value>
+          </spirit:parameter>
+        </spirit:parameters>
+      </spirit:view>
+      <spirit:view>
+        <spirit:name>xilinx_utilityxitfiles</spirit:name>
+        <spirit:displayName>Utility XIT/TTCL</spirit:displayName>
+        <spirit:envIdentifier>:vivado.xilinx.com:xit.util</spirit:envIdentifier>
+        <spirit:fileSetRef>
+          <spirit:localName>xilinx_utilityxitfiles_view_fileset</spirit:localName>
+        </spirit:fileSetRef>
+        <spirit:parameters>
+          <spirit:parameter>
+            <spirit:name>viewChecksum</spirit:name>
+            <spirit:value>495a496a</spirit:value>
+          </spirit:parameter>
+        </spirit:parameters>
+      </spirit:view>
+    </spirit:views>
+    <spirit:ports>
+      <spirit:port>
+        <spirit:name>i_controller_clk</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>i_ddr3_clk</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>i_ref_clk</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>i_ddr3_clk_90</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>i_rst_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ID_WIDTH&apos;)) - 1)">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awaddr</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ADDR_WIDTH&apos;)) - 1)">27</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awlen</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">7</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awsize</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">2</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awburst</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">1</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awlock</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">0</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awcache</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">3</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awprot</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">2</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_awqos</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_wvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_wready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_wdata</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_DATA_WIDTH&apos;)) - 1)">127</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_wstrb</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="((spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_DATA_WIDTH&apos;)) / 8) - 1)">15</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">1</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_wlast</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_bvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_bready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_bid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ID_WIDTH&apos;)) - 1)">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_bresp</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ID_WIDTH&apos;)) - 1)">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_araddr</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ADDR_WIDTH&apos;)) - 1)">27</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arlen</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">7</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arsize</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">2</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arburst</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">1</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arlock</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">0</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arcache</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">3</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arprot</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">2</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_arqos</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rvalid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rready</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+          <spirit:driver>
+            <spirit:defaultValue spirit:format="long">0</spirit:defaultValue>
+          </spirit:driver>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rid</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_ID_WIDTH&apos;)) - 1)">3</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rdata</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_DATA_WIDTH&apos;)) - 1)">127</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rlast</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>s_axi_rresp</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_clk_p</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_clk_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_reset_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_cke</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_cs_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_ras_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_cas_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_we_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_addr</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.ROW_BITS&apos;)) - 1)">13</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_ba_addr</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.BA_BITS&apos;)) - 1)">2</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>io_ddr3_dq</spirit:name>
+        <spirit:wire>
+          <spirit:direction>inout</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="((spirit:decode(id(&apos;MODELPARAM_VALUE.DQ_BITS&apos;)) * spirit:decode(id(&apos;MODELPARAM_VALUE.BYTE_LANES&apos;))) - 1)">15</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>io_ddr3_dqs</spirit:name>
+        <spirit:wire>
+          <spirit:direction>inout</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.BYTE_LANES&apos;)) - 1)">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>io_ddr3_dqs_n</spirit:name>
+        <spirit:wire>
+          <spirit:direction>inout</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.BYTE_LANES&apos;)) - 1)">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_dm</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long" spirit:resolve="dependent" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.BYTE_LANES&apos;)) - 1)">1</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_ddr3_odt</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_calib_complete</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>o_debug1</spirit:name>
+        <spirit:wire>
+          <spirit:direction>out</spirit:direction>
+          <spirit:vector>
+            <spirit:left spirit:format="long">31</spirit:left>
+            <spirit:right spirit:format="long">0</spirit:right>
+          </spirit:vector>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_anylanguagesynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_anylanguagebehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+    </spirit:ports>
+    <spirit:modelParameters>
+      <spirit:modelParameter xsi:type="spirit:nameValueTypeType" spirit:dataType="integer">
+        <spirit:name>CONTROLLER_CLK_PERIOD</spirit:name>
+        <spirit:displayName>Controller Clk Period</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD">12000</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>DDR3_CLK_PERIOD</spirit:name>
+        <spirit:displayName>Ddr3 Clk Period</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.DDR3_CLK_PERIOD">3000</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>ROW_BITS</spirit:name>
+        <spirit:displayName>Row Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.ROW_BITS">14</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>COL_BITS</spirit:name>
+        <spirit:displayName>Col Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.COL_BITS">10</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>BA_BITS</spirit:name>
+        <spirit:displayName>Ba Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.BA_BITS">3</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>BYTE_LANES</spirit:name>
+        <spirit:displayName>Byte Lanes</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.BYTE_LANES">2</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>AXI_ID_WIDTH</spirit:name>
+        <spirit:displayName>Axi Id Width</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.AXI_ID_WIDTH">4</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>WB2_ADDR_BITS</spirit:name>
+        <spirit:displayName>Wb2 Addr Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.WB2_ADDR_BITS">7</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>WB2_DATA_BITS</spirit:name>
+        <spirit:displayName>Wb2 Data Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.WB2_DATA_BITS">32</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>MICRON_SIM</spirit:name>
+        <spirit:displayName>Micron Sim</spirit:displayName>
+        <spirit:value spirit:format="bool" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.MICRON_SIM">false</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>ODELAY_SUPPORTED</spirit:name>
+        <spirit:displayName>Odelay Supported</spirit:displayName>
+        <spirit:value spirit:format="bool" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.ODELAY_SUPPORTED">false</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>SECOND_WISHBONE</spirit:name>
+        <spirit:displayName>Second Wishbone</spirit:displayName>
+        <spirit:value spirit:format="bool" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.SECOND_WISHBONE">false</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>WB_ERROR</spirit:name>
+        <spirit:displayName>Wb Error</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.WB_ERROR">0</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>SKIP_INTERNAL_TEST</spirit:name>
+        <spirit:displayName>Skip Internal Test</spirit:displayName>
+        <spirit:value spirit:format="bool" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.SKIP_INTERNAL_TEST">false</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>ECC_ENABLE</spirit:name>
+        <spirit:displayName>Ecc Enable</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.ECC_ENABLE">0</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>DIC</spirit:name>
+        <spirit:displayName>Dic</spirit:displayName>
+        <spirit:value spirit:format="bitString" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.DIC" spirit:bitStringLength="2">&quot;00&quot;</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>RTT_NOM</spirit:name>
+        <spirit:displayName>Rtt Nom</spirit:displayName>
+        <spirit:value spirit:format="bitString" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.RTT_NOM" spirit:bitStringLength="3">&quot;011&quot;</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>DQ_BITS</spirit:name>
+        <spirit:displayName>Dq Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.DQ_BITS">8</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>serdes_ratio</spirit:name>
+        <spirit:displayName>Serdes Ratio</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="generated" spirit:id="MODELPARAM_VALUE.serdes_ratio">4</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>wb_addr_bits</spirit:name>
+        <spirit:displayName>Wb Addr Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.wb_addr_bits" spirit:dependency="(((spirit:decode(id(&apos;MODELPARAM_VALUE.ROW_BITS&apos;)) + spirit:decode(id(&apos;MODELPARAM_VALUE.COL_BITS&apos;))) + spirit:decode(id(&apos;MODELPARAM_VALUE.BA_BITS&apos;))) - spirit:ceil(spirit:log(2,(spirit:decode(id(&apos;MODELPARAM_VALUE.serdes_ratio&apos;)) * 2))))">24</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>wb_data_bits</spirit:name>
+        <spirit:displayName>Wb Data Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.wb_data_bits" spirit:dependency="(((spirit:decode(id(&apos;MODELPARAM_VALUE.DQ_BITS&apos;)) * spirit:decode(id(&apos;MODELPARAM_VALUE.BYTE_LANES&apos;))) * spirit:decode(id(&apos;MODELPARAM_VALUE.serdes_ratio&apos;))) * 2)">128</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>wb_sel_bits</spirit:name>
+        <spirit:displayName>Wb Sel Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.wb_sel_bits" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.wb_data_bits&apos;)) / 8)">16</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>wb2_sel_bits</spirit:name>
+        <spirit:displayName>Wb2 Sel Bits</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.wb2_sel_bits" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.WB2_DATA_BITS&apos;)) / 8)">4</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>cmd_len</spirit:name>
+        <spirit:displayName>Cmd Len</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.cmd_len" spirit:dependency="(((4 + 3) + spirit:decode(id(&apos;MODELPARAM_VALUE.BA_BITS&apos;))) + spirit:decode(id(&apos;MODELPARAM_VALUE.ROW_BITS&apos;)))">24</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>AXI_LSBS</spirit:name>
+        <spirit:displayName>Axi Lsbs</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.AXI_LSBS" spirit:dependency="(spirit:ceil(spirit:log(2,spirit:decode(id(&apos;MODELPARAM_VALUE.wb_data_bits&apos;)))) - 3)">4</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>AXI_ADDR_WIDTH</spirit:name>
+        <spirit:displayName>Axi Addr Width</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.AXI_ADDR_WIDTH" spirit:dependency="(spirit:decode(id(&apos;MODELPARAM_VALUE.wb_addr_bits&apos;)) + spirit:decode(id(&apos;MODELPARAM_VALUE.AXI_LSBS&apos;)))">28</spirit:value>
+      </spirit:modelParameter>
+      <spirit:modelParameter spirit:dataType="integer">
+        <spirit:name>AXI_DATA_WIDTH</spirit:name>
+        <spirit:displayName>Axi Data Width</spirit:displayName>
+        <spirit:value spirit:format="long" spirit:resolve="dependent" spirit:id="MODELPARAM_VALUE.AXI_DATA_WIDTH" spirit:dependency="spirit:decode(id(&apos;MODELPARAM_VALUE.wb_data_bits&apos;))">128</spirit:value>
+      </spirit:modelParameter>
+    </spirit:modelParameters>
+  </spirit:model>
+  <spirit:choices>
+    <spirit:choice>
+      <spirit:name>choice_list_9d8b0d81</spirit:name>
+      <spirit:enumeration>ACTIVE_HIGH</spirit:enumeration>
+      <spirit:enumeration>ACTIVE_LOW</spirit:enumeration>
+    </spirit:choice>
+  </spirit:choices>
+  <spirit:fileSets>
+    <spirit:fileSet>
+      <spirit:name>xilinx_anylanguagesynthesis_view_fileset</spirit:name>
+      <spirit:file>
+        <spirit:name>../rtl/axi/axi_addr.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/axim2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/aximrd2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/aximwr2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_controller.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_phy.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_top.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/sfifo.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/skidbuffer.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/wbarbiter.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ecc/ecc_dec.sv</spirit:name>
+        <spirit:fileType>systemVerilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ecc/ecc_enc.sv</spirit:name>
+        <spirit:fileType>systemVerilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/ddr3_top_axi.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+        <spirit:userFileType>CHECKSUM_4123fcc3</spirit:userFileType>
+      </spirit:file>
+    </spirit:fileSet>
+    <spirit:fileSet>
+      <spirit:name>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:name>
+      <spirit:file>
+        <spirit:name>../rtl/axi/axi_addr.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/axim2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/aximrd2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/aximwr2wbsp.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_controller.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_phy.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ddr3_top.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/sfifo.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/skidbuffer.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/wbarbiter.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ecc/ecc_dec.sv</spirit:name>
+        <spirit:fileType>systemVerilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/ecc/ecc_enc.sv</spirit:name>
+        <spirit:fileType>systemVerilogSource</spirit:fileType>
+      </spirit:file>
+      <spirit:file>
+        <spirit:name>../rtl/axi/ddr3_top_axi.v</spirit:name>
+        <spirit:fileType>verilogSource</spirit:fileType>
+      </spirit:file>
+    </spirit:fileSet>
+    <spirit:fileSet>
+      <spirit:name>xilinx_xpgui_view_fileset</spirit:name>
+      <spirit:file>
+        <spirit:name>xgui/uberddr3_axi_v1_0.tcl</spirit:name>
+        <spirit:fileType>tclSource</spirit:fileType>
+        <spirit:userFileType>CHECKSUM_30e22270</spirit:userFileType>
+        <spirit:userFileType>XGUI_VERSION_2</spirit:userFileType>
+      </spirit:file>
+    </spirit:fileSet>
+    <spirit:fileSet>
+      <spirit:name>xilinx_utilityxitfiles_view_fileset</spirit:name>
+      <spirit:file>
+        <spirit:name>gui/uberddr3_axi_v1_0.gtcl</spirit:name>
+        <spirit:userFileType>GTCL</spirit:userFileType>
+      </spirit:file>
+    </spirit:fileSet>
+  </spirit:fileSets>
+  <spirit:description>UberDDR3 is an open-source DDR3 memory controller designed for Xilinx FPGAs. It features a 4:1 memory interface with customizable parameters, allowing seamless integration with a wide range of DDR3 memory devices. The user interface is AXI4-compliant</spirit:description>
+  <spirit:parameters>
+    <spirit:parameter>
+      <spirit:name>CONTROLLER_CLK_PERIOD</spirit:name>
+      <spirit:displayName>Controller Clock Period (ps)</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.CONTROLLER_CLK_PERIOD">12000</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>DDR3_CLK_PERIOD</spirit:name>
+      <spirit:displayName>DDR3 Clock Period (ps)</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.DDR3_CLK_PERIOD">3000</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.DDR3_CLK_PERIOD">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>ROW_BITS</spirit:name>
+      <spirit:displayName>Row Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.ROW_BITS">14</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>COL_BITS</spirit:name>
+      <spirit:displayName>Column Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.COL_BITS">10</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>BA_BITS</spirit:name>
+      <spirit:displayName>Bank Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.BA_BITS">3</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>BYTE_LANES</spirit:name>
+      <spirit:displayName>Byte Lanes</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.BYTE_LANES">2</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>AXI_ID_WIDTH</spirit:name>
+      <spirit:displayName>Axi Id Width</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.AXI_ID_WIDTH">4</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>WB2_ADDR_BITS</spirit:name>
+      <spirit:displayName>Wb2 Addr Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.WB2_ADDR_BITS">7</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>WB2_DATA_BITS</spirit:name>
+      <spirit:displayName>Wb2 Data Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.WB2_DATA_BITS">32</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>MICRON_SIM</spirit:name>
+      <spirit:displayName>Micron Simulation</spirit:displayName>
+      <spirit:value spirit:format="bool" spirit:resolve="user" spirit:id="PARAM_VALUE.MICRON_SIM">false</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>ODELAY_SUPPORTED</spirit:name>
+      <spirit:displayName>ODELAY Supported</spirit:displayName>
+      <spirit:value spirit:format="bool" spirit:resolve="user" spirit:id="PARAM_VALUE.ODELAY_SUPPORTED">false</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>SECOND_WISHBONE</spirit:name>
+      <spirit:displayName>Second Wishbone</spirit:displayName>
+      <spirit:value spirit:format="bool" spirit:resolve="user" spirit:id="PARAM_VALUE.SECOND_WISHBONE">false</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>WB_ERROR</spirit:name>
+      <spirit:displayName>Wb Error</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.WB_ERROR">0</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>SKIP_INTERNAL_TEST</spirit:name>
+      <spirit:displayName>Skip Internal Test</spirit:displayName>
+      <spirit:value spirit:format="bool" spirit:resolve="user" spirit:id="PARAM_VALUE.SKIP_INTERNAL_TEST">false</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>ECC_ENABLE</spirit:name>
+      <spirit:displayName>ECC Enable</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.ECC_ENABLE" spirit:minimum="0" spirit:maximum="3" spirit:rangeType="long">0</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>DIC</spirit:name>
+      <spirit:displayName>Dic</spirit:displayName>
+      <spirit:value spirit:format="bitString" spirit:resolve="user" spirit:id="PARAM_VALUE.DIC" spirit:bitStringLength="2">&quot;00&quot;</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>RTT_NOM</spirit:name>
+      <spirit:displayName>Rtt Nom</spirit:displayName>
+      <spirit:value spirit:format="bitString" spirit:resolve="user" spirit:id="PARAM_VALUE.RTT_NOM" spirit:bitStringLength="3">&quot;011&quot;</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>DQ_BITS</spirit:name>
+      <spirit:displayName>Dq Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.DQ_BITS">8</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>serdes_ratio</spirit:name>
+      <spirit:displayName>Serdes Ratio</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.serdes_ratio">4</spirit:value>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>wb_addr_bits</spirit:name>
+      <spirit:displayName>Wb Addr Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.wb_addr_bits">24</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.wb_addr_bits">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>wb_data_bits</spirit:name>
+      <spirit:displayName>Wb Data Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.wb_data_bits">128</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.wb_data_bits">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>wb_sel_bits</spirit:name>
+      <spirit:displayName>Wb Sel Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.wb_sel_bits">16</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.wb_sel_bits">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>wb2_sel_bits</spirit:name>
+      <spirit:displayName>Wb2 Sel Bits</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.wb2_sel_bits">4</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.wb2_sel_bits">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>cmd_len</spirit:name>
+      <spirit:displayName>Cmd Len</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.cmd_len">24</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.cmd_len">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>AXI_LSBS</spirit:name>
+      <spirit:displayName>Axi Lsbs</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.AXI_LSBS">4</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.AXI_LSBS">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>AXI_ADDR_WIDTH</spirit:name>
+      <spirit:displayName>Axi Addr Width</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.AXI_ADDR_WIDTH">28</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.AXI_ADDR_WIDTH">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>AXI_DATA_WIDTH</spirit:name>
+      <spirit:displayName>Axi Data Width</spirit:displayName>
+      <spirit:value spirit:format="long" spirit:resolve="user" spirit:id="PARAM_VALUE.AXI_DATA_WIDTH">128</spirit:value>
+      <spirit:vendorExtensions>
+        <xilinx:parameterInfo>
+          <xilinx:enablement>
+            <xilinx:isEnabled xilinx:id="PARAM_ENABLEMENT.AXI_DATA_WIDTH">false</xilinx:isEnabled>
+          </xilinx:enablement>
+        </xilinx:parameterInfo>
+      </spirit:vendorExtensions>
+    </spirit:parameter>
+    <spirit:parameter>
+      <spirit:name>Component_Name</spirit:name>
+      <spirit:value spirit:resolve="user" spirit:id="PARAM_VALUE.Component_Name" spirit:order="1">uberddr3_axi_v1_0</spirit:value>
+    </spirit:parameter>
+  </spirit:parameters>
+  <spirit:vendorExtensions>
+    <xilinx:coreExtensions>
+      <xilinx:supportedFamilies>
+        <xilinx:family xilinx:lifeCycle="Production">virtex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qvirtex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">versal</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintex7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qkintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qkintex7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">akintex7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">artix7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">artix7l</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">aartix7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qartix7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">zynq</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">qzynq</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">azynq</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">spartan7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">aspartan7</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtexu</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">zynquplus</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtexuplus</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">virtexuplusHBM</xilinx:family>
+        <xilinx:family xilinx:lifeCycle="Production">kintexu</xilinx:family>
+      </xilinx:supportedFamilies>
+      <xilinx:taxonomies>
+        <xilinx:taxonomy>/UserIP</xilinx:taxonomy>
+      </xilinx:taxonomies>
+      <xilinx:displayName>uberddr3_axi_v1_0</xilinx:displayName>
+      <xilinx:definitionSource>package_project</xilinx:definitionSource>
+      <xilinx:vendorURL>https://github.com/AngeloJacobo/UberDDR3</xilinx:vendorURL>
+      <xilinx:coreRevision>9</xilinx:coreRevision>
+      <xilinx:coreCreationDateTime>2024-10-19T05:33:11Z</xilinx:coreCreationDateTime>
+      <xilinx:tags>
+        <xilinx:tag xilinx:name="nopcore"/>
+      </xilinx:tags>
+    </xilinx:coreExtensions>
+    <xilinx:packagingInfo>
+      <xilinx:xilinxVersion>2022.1</xilinx:xilinxVersion>
+      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="a8e6cc4e"/>
+      <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="cd65c31e"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="68e3a14b"/>
+      <xilinx:checksum xilinx:scope="ports" xilinx:value="a969876f"/>
+      <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="86f21185"/>
+      <xilinx:checksum xilinx:scope="parameters" xilinx:value="17670e8c"/>
+    </xilinx:packagingInfo>
+  </spirit:vendorExtensions>
+</spirit:component>

--- a/vivado_custom_ip/gui/uberddr3_axi_v1_0.gtcl
+++ b/vivado_custom_ip/gui/uberddr3_axi_v1_0.gtcl
@@ -1,0 +1,10 @@
+# This file is automatically written.  Do not modify.
+proc gen_USERPARAMETER_DDR3_CLK_PERIOD_VALUE {CONTROLLER_CLK_PERIOD } {expr $CONTROLLER_CLK_PERIOD / 4}
+proc gen_USERPARAMETER_wb_addr_bits_VALUE {ROW_BITS COL_BITS BA_BITS } {expr $ROW_BITS + $COL_BITS + $BA_BITS - 3}
+proc gen_USERPARAMETER_wb_data_bits_VALUE {DQ_BITS BYTE_LANES } {expr $DQ_BITS * $BYTE_LANES * 8}
+proc gen_USERPARAMETER_wb_sel_bits_VALUE {wb_data_bits } {expr $wb_data_bits / 8}
+proc gen_USERPARAMETER_wb2_sel_bits_VALUE {WB2_DATA_BITS } {expr $WB2_DATA_BITS / 8}
+proc gen_USERPARAMETER_cmd_len_VALUE {BA_BITS ROW_BITS } {expr 4 + 3 + $BA_BITS + $ROW_BITS}
+proc gen_USERPARAMETER_AXI_LSBS_VALUE {wb_data_bits } {expr (log( $wb_data_bits )/log(2)) - 3}
+proc gen_USERPARAMETER_AXI_ADDR_WIDTH_VALUE {wb_addr_bits AXI_LSBS } {expr $wb_addr_bits + $AXI_LSBS}
+proc gen_USERPARAMETER_AXI_DATA_WIDTH_VALUE {wb_data_bits } {expr $wb_data_bits}

--- a/vivado_custom_ip/xgui/ddr3_top_axi_v1_0.tcl
+++ b/vivado_custom_ip/xgui/ddr3_top_axi_v1_0.tcl
@@ -1,0 +1,415 @@
+# Definitional proc to organize widgets for parameters.
+proc init_gui { IPINST } {
+  ipgui::add_param $IPINST -name "Component_Name"
+  #Adding Page
+  set Page_0 [ipgui::add_page $IPINST -name "Page 0"]
+  ipgui::add_param $IPINST -name "AXI_ADDR_WIDTH" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "AXI_DATA_WIDTH" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "AXI_ID_WIDTH" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "AXI_LSBS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "BA_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "BYTE_LANES" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "COL_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "CONTROLLER_CLK_PERIOD" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "DDR3_CLK_PERIOD" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "DIC" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "DQ_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "ECC_ENABLE" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "MICRON_SIM" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "ODELAY_SUPPORTED" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "ROW_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "RTT_NOM" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "SECOND_WISHBONE" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "SKIP_INTERNAL_TEST" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "WB2_ADDR_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "WB2_DATA_BITS" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "WB_ERROR" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "cmd_len" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "serdes_ratio" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "wb2_sel_bits" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "wb_addr_bits" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "wb_data_bits" -parent ${Page_0}
+  ipgui::add_param $IPINST -name "wb_sel_bits" -parent ${Page_0}
+
+
+}
+
+proc update_PARAM_VALUE.AXI_ADDR_WIDTH { PARAM_VALUE.AXI_ADDR_WIDTH } {
+	# Procedure called to update AXI_ADDR_WIDTH when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.AXI_ADDR_WIDTH { PARAM_VALUE.AXI_ADDR_WIDTH } {
+	# Procedure called to validate AXI_ADDR_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_DATA_WIDTH { PARAM_VALUE.AXI_DATA_WIDTH } {
+	# Procedure called to update AXI_DATA_WIDTH when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.AXI_DATA_WIDTH { PARAM_VALUE.AXI_DATA_WIDTH } {
+	# Procedure called to validate AXI_DATA_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_ID_WIDTH { PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to update AXI_ID_WIDTH when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.AXI_ID_WIDTH { PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to validate AXI_ID_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_LSBS { PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to update AXI_LSBS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.AXI_LSBS { PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to validate AXI_LSBS
+	return true
+}
+
+proc update_PARAM_VALUE.BA_BITS { PARAM_VALUE.BA_BITS } {
+	# Procedure called to update BA_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.BA_BITS { PARAM_VALUE.BA_BITS } {
+	# Procedure called to validate BA_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.BYTE_LANES { PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to update BYTE_LANES when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.BYTE_LANES { PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to validate BYTE_LANES
+	return true
+}
+
+proc update_PARAM_VALUE.COL_BITS { PARAM_VALUE.COL_BITS } {
+	# Procedure called to update COL_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.COL_BITS { PARAM_VALUE.COL_BITS } {
+	# Procedure called to validate COL_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.CONTROLLER_CLK_PERIOD { PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to update CONTROLLER_CLK_PERIOD when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.CONTROLLER_CLK_PERIOD { PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to validate CONTROLLER_CLK_PERIOD
+	return true
+}
+
+proc update_PARAM_VALUE.DDR3_CLK_PERIOD { PARAM_VALUE.DDR3_CLK_PERIOD } {
+	# Procedure called to update DDR3_CLK_PERIOD when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.DDR3_CLK_PERIOD { PARAM_VALUE.DDR3_CLK_PERIOD } {
+	# Procedure called to validate DDR3_CLK_PERIOD
+	return true
+}
+
+proc update_PARAM_VALUE.DIC { PARAM_VALUE.DIC } {
+	# Procedure called to update DIC when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.DIC { PARAM_VALUE.DIC } {
+	# Procedure called to validate DIC
+	return true
+}
+
+proc update_PARAM_VALUE.DQ_BITS { PARAM_VALUE.DQ_BITS } {
+	# Procedure called to update DQ_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.DQ_BITS { PARAM_VALUE.DQ_BITS } {
+	# Procedure called to validate DQ_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.ECC_ENABLE { PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to update ECC_ENABLE when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ECC_ENABLE { PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to validate ECC_ENABLE
+	return true
+}
+
+proc update_PARAM_VALUE.MICRON_SIM { PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to update MICRON_SIM when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.MICRON_SIM { PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to validate MICRON_SIM
+	return true
+}
+
+proc update_PARAM_VALUE.ODELAY_SUPPORTED { PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to update ODELAY_SUPPORTED when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ODELAY_SUPPORTED { PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to validate ODELAY_SUPPORTED
+	return true
+}
+
+proc update_PARAM_VALUE.ROW_BITS { PARAM_VALUE.ROW_BITS } {
+	# Procedure called to update ROW_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ROW_BITS { PARAM_VALUE.ROW_BITS } {
+	# Procedure called to validate ROW_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.RTT_NOM { PARAM_VALUE.RTT_NOM } {
+	# Procedure called to update RTT_NOM when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.RTT_NOM { PARAM_VALUE.RTT_NOM } {
+	# Procedure called to validate RTT_NOM
+	return true
+}
+
+proc update_PARAM_VALUE.SECOND_WISHBONE { PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to update SECOND_WISHBONE when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.SECOND_WISHBONE { PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to validate SECOND_WISHBONE
+	return true
+}
+
+proc update_PARAM_VALUE.SKIP_INTERNAL_TEST { PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to update SKIP_INTERNAL_TEST when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.SKIP_INTERNAL_TEST { PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to validate SKIP_INTERNAL_TEST
+	return true
+}
+
+proc update_PARAM_VALUE.WB2_ADDR_BITS { PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to update WB2_ADDR_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB2_ADDR_BITS { PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to validate WB2_ADDR_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.WB2_DATA_BITS { PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to update WB2_DATA_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB2_DATA_BITS { PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to validate WB2_DATA_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.WB_ERROR { PARAM_VALUE.WB_ERROR } {
+	# Procedure called to update WB_ERROR when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB_ERROR { PARAM_VALUE.WB_ERROR } {
+	# Procedure called to validate WB_ERROR
+	return true
+}
+
+proc update_PARAM_VALUE.cmd_len { PARAM_VALUE.cmd_len } {
+	# Procedure called to update cmd_len when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.cmd_len { PARAM_VALUE.cmd_len } {
+	# Procedure called to validate cmd_len
+	return true
+}
+
+proc update_PARAM_VALUE.serdes_ratio { PARAM_VALUE.serdes_ratio } {
+	# Procedure called to update serdes_ratio when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.serdes_ratio { PARAM_VALUE.serdes_ratio } {
+	# Procedure called to validate serdes_ratio
+	return true
+}
+
+proc update_PARAM_VALUE.wb2_sel_bits { PARAM_VALUE.wb2_sel_bits } {
+	# Procedure called to update wb2_sel_bits when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.wb2_sel_bits { PARAM_VALUE.wb2_sel_bits } {
+	# Procedure called to validate wb2_sel_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_addr_bits { PARAM_VALUE.wb_addr_bits } {
+	# Procedure called to update wb_addr_bits when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.wb_addr_bits { PARAM_VALUE.wb_addr_bits } {
+	# Procedure called to validate wb_addr_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_data_bits { PARAM_VALUE.wb_data_bits } {
+	# Procedure called to update wb_data_bits when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.wb_data_bits { PARAM_VALUE.wb_data_bits } {
+	# Procedure called to validate wb_data_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_sel_bits { PARAM_VALUE.wb_sel_bits } {
+	# Procedure called to update wb_sel_bits when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.wb_sel_bits { PARAM_VALUE.wb_sel_bits } {
+	# Procedure called to validate wb_sel_bits
+	return true
+}
+
+
+proc update_MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD { MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.CONTROLLER_CLK_PERIOD}] ${MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD}
+}
+
+proc update_MODELPARAM_VALUE.DDR3_CLK_PERIOD { MODELPARAM_VALUE.DDR3_CLK_PERIOD PARAM_VALUE.DDR3_CLK_PERIOD } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DDR3_CLK_PERIOD}] ${MODELPARAM_VALUE.DDR3_CLK_PERIOD}
+}
+
+proc update_MODELPARAM_VALUE.ROW_BITS { MODELPARAM_VALUE.ROW_BITS PARAM_VALUE.ROW_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ROW_BITS}] ${MODELPARAM_VALUE.ROW_BITS}
+}
+
+proc update_MODELPARAM_VALUE.COL_BITS { MODELPARAM_VALUE.COL_BITS PARAM_VALUE.COL_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.COL_BITS}] ${MODELPARAM_VALUE.COL_BITS}
+}
+
+proc update_MODELPARAM_VALUE.BA_BITS { MODELPARAM_VALUE.BA_BITS PARAM_VALUE.BA_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.BA_BITS}] ${MODELPARAM_VALUE.BA_BITS}
+}
+
+proc update_MODELPARAM_VALUE.BYTE_LANES { MODELPARAM_VALUE.BYTE_LANES PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.BYTE_LANES}] ${MODELPARAM_VALUE.BYTE_LANES}
+}
+
+proc update_MODELPARAM_VALUE.AXI_ID_WIDTH { MODELPARAM_VALUE.AXI_ID_WIDTH PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_ID_WIDTH}] ${MODELPARAM_VALUE.AXI_ID_WIDTH}
+}
+
+proc update_MODELPARAM_VALUE.WB2_ADDR_BITS { MODELPARAM_VALUE.WB2_ADDR_BITS PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB2_ADDR_BITS}] ${MODELPARAM_VALUE.WB2_ADDR_BITS}
+}
+
+proc update_MODELPARAM_VALUE.WB2_DATA_BITS { MODELPARAM_VALUE.WB2_DATA_BITS PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB2_DATA_BITS}] ${MODELPARAM_VALUE.WB2_DATA_BITS}
+}
+
+proc update_MODELPARAM_VALUE.MICRON_SIM { MODELPARAM_VALUE.MICRON_SIM PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.MICRON_SIM}] ${MODELPARAM_VALUE.MICRON_SIM}
+}
+
+proc update_MODELPARAM_VALUE.ODELAY_SUPPORTED { MODELPARAM_VALUE.ODELAY_SUPPORTED PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ODELAY_SUPPORTED}] ${MODELPARAM_VALUE.ODELAY_SUPPORTED}
+}
+
+proc update_MODELPARAM_VALUE.SECOND_WISHBONE { MODELPARAM_VALUE.SECOND_WISHBONE PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.SECOND_WISHBONE}] ${MODELPARAM_VALUE.SECOND_WISHBONE}
+}
+
+proc update_MODELPARAM_VALUE.WB_ERROR { MODELPARAM_VALUE.WB_ERROR PARAM_VALUE.WB_ERROR } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB_ERROR}] ${MODELPARAM_VALUE.WB_ERROR}
+}
+
+proc update_MODELPARAM_VALUE.SKIP_INTERNAL_TEST { MODELPARAM_VALUE.SKIP_INTERNAL_TEST PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.SKIP_INTERNAL_TEST}] ${MODELPARAM_VALUE.SKIP_INTERNAL_TEST}
+}
+
+proc update_MODELPARAM_VALUE.ECC_ENABLE { MODELPARAM_VALUE.ECC_ENABLE PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ECC_ENABLE}] ${MODELPARAM_VALUE.ECC_ENABLE}
+}
+
+proc update_MODELPARAM_VALUE.DIC { MODELPARAM_VALUE.DIC PARAM_VALUE.DIC } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DIC}] ${MODELPARAM_VALUE.DIC}
+}
+
+proc update_MODELPARAM_VALUE.RTT_NOM { MODELPARAM_VALUE.RTT_NOM PARAM_VALUE.RTT_NOM } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.RTT_NOM}] ${MODELPARAM_VALUE.RTT_NOM}
+}
+
+proc update_MODELPARAM_VALUE.DQ_BITS { MODELPARAM_VALUE.DQ_BITS PARAM_VALUE.DQ_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DQ_BITS}] ${MODELPARAM_VALUE.DQ_BITS}
+}
+
+proc update_MODELPARAM_VALUE.serdes_ratio { MODELPARAM_VALUE.serdes_ratio PARAM_VALUE.serdes_ratio } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.serdes_ratio}] ${MODELPARAM_VALUE.serdes_ratio}
+}
+
+proc update_MODELPARAM_VALUE.wb_addr_bits { MODELPARAM_VALUE.wb_addr_bits PARAM_VALUE.wb_addr_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_addr_bits}] ${MODELPARAM_VALUE.wb_addr_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb_data_bits { MODELPARAM_VALUE.wb_data_bits PARAM_VALUE.wb_data_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_data_bits}] ${MODELPARAM_VALUE.wb_data_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb_sel_bits { MODELPARAM_VALUE.wb_sel_bits PARAM_VALUE.wb_sel_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_sel_bits}] ${MODELPARAM_VALUE.wb_sel_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb2_sel_bits { MODELPARAM_VALUE.wb2_sel_bits PARAM_VALUE.wb2_sel_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb2_sel_bits}] ${MODELPARAM_VALUE.wb2_sel_bits}
+}
+
+proc update_MODELPARAM_VALUE.cmd_len { MODELPARAM_VALUE.cmd_len PARAM_VALUE.cmd_len } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.cmd_len}] ${MODELPARAM_VALUE.cmd_len}
+}
+
+proc update_MODELPARAM_VALUE.AXI_LSBS { MODELPARAM_VALUE.AXI_LSBS PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_LSBS}] ${MODELPARAM_VALUE.AXI_LSBS}
+}
+
+proc update_MODELPARAM_VALUE.AXI_ADDR_WIDTH { MODELPARAM_VALUE.AXI_ADDR_WIDTH PARAM_VALUE.AXI_ADDR_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_ADDR_WIDTH}] ${MODELPARAM_VALUE.AXI_ADDR_WIDTH}
+}
+
+proc update_MODELPARAM_VALUE.AXI_DATA_WIDTH { MODELPARAM_VALUE.AXI_DATA_WIDTH PARAM_VALUE.AXI_DATA_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_DATA_WIDTH}] ${MODELPARAM_VALUE.AXI_DATA_WIDTH}
+}
+

--- a/vivado_custom_ip/xgui/uberddr3_axi_v1_0.tcl
+++ b/vivado_custom_ip/xgui/uberddr3_axi_v1_0.tcl
@@ -1,0 +1,467 @@
+
+# Loading additional proc with user specified bodies to compute parameter values.
+source [file join [file dirname [file dirname [info script]]] gui/uberddr3_axi_v1_0.gtcl]
+
+# Definitional proc to organize widgets for parameters.
+proc init_gui { IPINST } {
+  ipgui::add_param $IPINST -name "Component_Name"
+  #Adding Page
+  set Page_0 [ipgui::add_page $IPINST -name "Page 0"]
+  set CONTROLLER_CLK_PERIOD [ipgui::add_param $IPINST -name "CONTROLLER_CLK_PERIOD" -parent ${Page_0}]
+  set_property tooltip {Clock period of the controller interface in picoseconds} ${CONTROLLER_CLK_PERIOD}
+  set DDR3_CLK_PERIOD [ipgui::add_param $IPINST -name "DDR3_CLK_PERIOD" -parent ${Page_0}]
+  set_property tooltip {1/4 of Controller Clock Period} ${DDR3_CLK_PERIOD}
+  set ROW_BITS [ipgui::add_param $IPINST -name "ROW_BITS" -parent ${Page_0}]
+  set_property tooltip {Width of row address} ${ROW_BITS}
+  set COL_BITS [ipgui::add_param $IPINST -name "COL_BITS" -parent ${Page_0}]
+  set_property tooltip {Width of column address} ${COL_BITS}
+  set BA_BITS [ipgui::add_param $IPINST -name "BA_BITS" -parent ${Page_0}]
+  set_property tooltip {Width of bank address} ${BA_BITS}
+  set BYTE_LANES [ipgui::add_param $IPINST -name "BYTE_LANES" -parent ${Page_0}]
+  set_property tooltip {Number of byte lanes of DDR3 RAM in the FPGA board (e.g. x16 DDR3 will have 2 byte lanes)} ${BYTE_LANES}
+  set ECC_ENABLE [ipgui::add_param $IPINST -name "ECC_ENABLE" -parent ${Page_0}]
+  set_property tooltip {0 = DIsabled, 1 = Side-band ECC per burst, 2 = Side-band ECC per 8 bursts , 3 = Inline ECC} ${ECC_ENABLE}
+  set SKIP_INTERNAL_TEST [ipgui::add_param $IPINST -name "SKIP_INTERNAL_TEST" -parent ${Page_0}]
+  set_property tooltip {Check to skip built-in self-test (check this if UberDDR3 will be connected to Microblaze)} ${SKIP_INTERNAL_TEST}
+  set ODELAY_SUPPORTED [ipgui::add_param $IPINST -name "ODELAY_SUPPORTED" -parent ${Page_0}]
+  set_property tooltip {Check if FPGA supports ODELAYE2 primitive (e.g. FPGA with HP banks like Kintex-7)} ${ODELAY_SUPPORTED}
+  set MICRON_SIM [ipgui::add_param $IPINST -name "MICRON_SIM" -parent ${Page_0}]
+  set_property tooltip {Check if design will be run on simulation to shorten calibration} ${MICRON_SIM}
+
+
+}
+
+proc update_PARAM_VALUE.AXI_ADDR_WIDTH { PARAM_VALUE.AXI_ADDR_WIDTH PARAM_VALUE.wb_addr_bits PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to update AXI_ADDR_WIDTH when any of the dependent parameters in the arguments change
+	
+	set AXI_ADDR_WIDTH ${PARAM_VALUE.AXI_ADDR_WIDTH}
+	set wb_addr_bits ${PARAM_VALUE.wb_addr_bits}
+	set AXI_LSBS ${PARAM_VALUE.AXI_LSBS}
+	set values(wb_addr_bits) [get_property value $wb_addr_bits]
+	set values(AXI_LSBS) [get_property value $AXI_LSBS]
+	set_property value [gen_USERPARAMETER_AXI_ADDR_WIDTH_VALUE $values(wb_addr_bits) $values(AXI_LSBS)] $AXI_ADDR_WIDTH
+}
+
+proc validate_PARAM_VALUE.AXI_ADDR_WIDTH { PARAM_VALUE.AXI_ADDR_WIDTH } {
+	# Procedure called to validate AXI_ADDR_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_DATA_WIDTH { PARAM_VALUE.AXI_DATA_WIDTH PARAM_VALUE.wb_data_bits } {
+	# Procedure called to update AXI_DATA_WIDTH when any of the dependent parameters in the arguments change
+	
+	set AXI_DATA_WIDTH ${PARAM_VALUE.AXI_DATA_WIDTH}
+	set wb_data_bits ${PARAM_VALUE.wb_data_bits}
+	set values(wb_data_bits) [get_property value $wb_data_bits]
+	set_property value [gen_USERPARAMETER_AXI_DATA_WIDTH_VALUE $values(wb_data_bits)] $AXI_DATA_WIDTH
+}
+
+proc validate_PARAM_VALUE.AXI_DATA_WIDTH { PARAM_VALUE.AXI_DATA_WIDTH } {
+	# Procedure called to validate AXI_DATA_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_LSBS { PARAM_VALUE.AXI_LSBS PARAM_VALUE.wb_data_bits } {
+	# Procedure called to update AXI_LSBS when any of the dependent parameters in the arguments change
+	
+	set AXI_LSBS ${PARAM_VALUE.AXI_LSBS}
+	set wb_data_bits ${PARAM_VALUE.wb_data_bits}
+	set values(wb_data_bits) [get_property value $wb_data_bits]
+	set_property value [gen_USERPARAMETER_AXI_LSBS_VALUE $values(wb_data_bits)] $AXI_LSBS
+}
+
+proc validate_PARAM_VALUE.AXI_LSBS { PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to validate AXI_LSBS
+	return true
+}
+
+proc update_PARAM_VALUE.DDR3_CLK_PERIOD { PARAM_VALUE.DDR3_CLK_PERIOD PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to update DDR3_CLK_PERIOD when any of the dependent parameters in the arguments change
+	
+	set DDR3_CLK_PERIOD ${PARAM_VALUE.DDR3_CLK_PERIOD}
+	set CONTROLLER_CLK_PERIOD ${PARAM_VALUE.CONTROLLER_CLK_PERIOD}
+	set values(CONTROLLER_CLK_PERIOD) [get_property value $CONTROLLER_CLK_PERIOD]
+	set_property value [gen_USERPARAMETER_DDR3_CLK_PERIOD_VALUE $values(CONTROLLER_CLK_PERIOD)] $DDR3_CLK_PERIOD
+}
+
+proc validate_PARAM_VALUE.DDR3_CLK_PERIOD { PARAM_VALUE.DDR3_CLK_PERIOD } {
+	# Procedure called to validate DDR3_CLK_PERIOD
+	return true
+}
+
+proc update_PARAM_VALUE.cmd_len { PARAM_VALUE.cmd_len PARAM_VALUE.BA_BITS PARAM_VALUE.ROW_BITS } {
+	# Procedure called to update cmd_len when any of the dependent parameters in the arguments change
+	
+	set cmd_len ${PARAM_VALUE.cmd_len}
+	set BA_BITS ${PARAM_VALUE.BA_BITS}
+	set ROW_BITS ${PARAM_VALUE.ROW_BITS}
+	set values(BA_BITS) [get_property value $BA_BITS]
+	set values(ROW_BITS) [get_property value $ROW_BITS]
+	set_property value [gen_USERPARAMETER_cmd_len_VALUE $values(BA_BITS) $values(ROW_BITS)] $cmd_len
+}
+
+proc validate_PARAM_VALUE.cmd_len { PARAM_VALUE.cmd_len } {
+	# Procedure called to validate cmd_len
+	return true
+}
+
+proc update_PARAM_VALUE.wb2_sel_bits { PARAM_VALUE.wb2_sel_bits PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to update wb2_sel_bits when any of the dependent parameters in the arguments change
+	
+	set wb2_sel_bits ${PARAM_VALUE.wb2_sel_bits}
+	set WB2_DATA_BITS ${PARAM_VALUE.WB2_DATA_BITS}
+	set values(WB2_DATA_BITS) [get_property value $WB2_DATA_BITS]
+	set_property value [gen_USERPARAMETER_wb2_sel_bits_VALUE $values(WB2_DATA_BITS)] $wb2_sel_bits
+}
+
+proc validate_PARAM_VALUE.wb2_sel_bits { PARAM_VALUE.wb2_sel_bits } {
+	# Procedure called to validate wb2_sel_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_addr_bits { PARAM_VALUE.wb_addr_bits PARAM_VALUE.ROW_BITS PARAM_VALUE.COL_BITS PARAM_VALUE.BA_BITS } {
+	# Procedure called to update wb_addr_bits when any of the dependent parameters in the arguments change
+	
+	set wb_addr_bits ${PARAM_VALUE.wb_addr_bits}
+	set ROW_BITS ${PARAM_VALUE.ROW_BITS}
+	set COL_BITS ${PARAM_VALUE.COL_BITS}
+	set BA_BITS ${PARAM_VALUE.BA_BITS}
+	set values(ROW_BITS) [get_property value $ROW_BITS]
+	set values(COL_BITS) [get_property value $COL_BITS]
+	set values(BA_BITS) [get_property value $BA_BITS]
+	set_property value [gen_USERPARAMETER_wb_addr_bits_VALUE $values(ROW_BITS) $values(COL_BITS) $values(BA_BITS)] $wb_addr_bits
+}
+
+proc validate_PARAM_VALUE.wb_addr_bits { PARAM_VALUE.wb_addr_bits } {
+	# Procedure called to validate wb_addr_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_data_bits { PARAM_VALUE.wb_data_bits PARAM_VALUE.DQ_BITS PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to update wb_data_bits when any of the dependent parameters in the arguments change
+	
+	set wb_data_bits ${PARAM_VALUE.wb_data_bits}
+	set DQ_BITS ${PARAM_VALUE.DQ_BITS}
+	set BYTE_LANES ${PARAM_VALUE.BYTE_LANES}
+	set values(DQ_BITS) [get_property value $DQ_BITS]
+	set values(BYTE_LANES) [get_property value $BYTE_LANES]
+	set_property value [gen_USERPARAMETER_wb_data_bits_VALUE $values(DQ_BITS) $values(BYTE_LANES)] $wb_data_bits
+}
+
+proc validate_PARAM_VALUE.wb_data_bits { PARAM_VALUE.wb_data_bits } {
+	# Procedure called to validate wb_data_bits
+	return true
+}
+
+proc update_PARAM_VALUE.wb_sel_bits { PARAM_VALUE.wb_sel_bits PARAM_VALUE.wb_data_bits } {
+	# Procedure called to update wb_sel_bits when any of the dependent parameters in the arguments change
+	
+	set wb_sel_bits ${PARAM_VALUE.wb_sel_bits}
+	set wb_data_bits ${PARAM_VALUE.wb_data_bits}
+	set values(wb_data_bits) [get_property value $wb_data_bits]
+	set_property value [gen_USERPARAMETER_wb_sel_bits_VALUE $values(wb_data_bits)] $wb_sel_bits
+}
+
+proc validate_PARAM_VALUE.wb_sel_bits { PARAM_VALUE.wb_sel_bits } {
+	# Procedure called to validate wb_sel_bits
+	return true
+}
+
+proc update_PARAM_VALUE.AXI_ID_WIDTH { PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to update AXI_ID_WIDTH when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.AXI_ID_WIDTH { PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to validate AXI_ID_WIDTH
+	return true
+}
+
+proc update_PARAM_VALUE.BA_BITS { PARAM_VALUE.BA_BITS } {
+	# Procedure called to update BA_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.BA_BITS { PARAM_VALUE.BA_BITS } {
+	# Procedure called to validate BA_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.BYTE_LANES { PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to update BYTE_LANES when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.BYTE_LANES { PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to validate BYTE_LANES
+	return true
+}
+
+proc update_PARAM_VALUE.COL_BITS { PARAM_VALUE.COL_BITS } {
+	# Procedure called to update COL_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.COL_BITS { PARAM_VALUE.COL_BITS } {
+	# Procedure called to validate COL_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.CONTROLLER_CLK_PERIOD { PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to update CONTROLLER_CLK_PERIOD when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.CONTROLLER_CLK_PERIOD { PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to validate CONTROLLER_CLK_PERIOD
+	return true
+}
+
+proc update_PARAM_VALUE.DIC { PARAM_VALUE.DIC } {
+	# Procedure called to update DIC when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.DIC { PARAM_VALUE.DIC } {
+	# Procedure called to validate DIC
+	return true
+}
+
+proc update_PARAM_VALUE.DQ_BITS { PARAM_VALUE.DQ_BITS } {
+	# Procedure called to update DQ_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.DQ_BITS { PARAM_VALUE.DQ_BITS } {
+	# Procedure called to validate DQ_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.ECC_ENABLE { PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to update ECC_ENABLE when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ECC_ENABLE { PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to validate ECC_ENABLE
+	return true
+}
+
+proc update_PARAM_VALUE.MICRON_SIM { PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to update MICRON_SIM when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.MICRON_SIM { PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to validate MICRON_SIM
+	return true
+}
+
+proc update_PARAM_VALUE.ODELAY_SUPPORTED { PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to update ODELAY_SUPPORTED when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ODELAY_SUPPORTED { PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to validate ODELAY_SUPPORTED
+	return true
+}
+
+proc update_PARAM_VALUE.ROW_BITS { PARAM_VALUE.ROW_BITS } {
+	# Procedure called to update ROW_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.ROW_BITS { PARAM_VALUE.ROW_BITS } {
+	# Procedure called to validate ROW_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.RTT_NOM { PARAM_VALUE.RTT_NOM } {
+	# Procedure called to update RTT_NOM when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.RTT_NOM { PARAM_VALUE.RTT_NOM } {
+	# Procedure called to validate RTT_NOM
+	return true
+}
+
+proc update_PARAM_VALUE.SECOND_WISHBONE { PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to update SECOND_WISHBONE when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.SECOND_WISHBONE { PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to validate SECOND_WISHBONE
+	return true
+}
+
+proc update_PARAM_VALUE.SKIP_INTERNAL_TEST { PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to update SKIP_INTERNAL_TEST when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.SKIP_INTERNAL_TEST { PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to validate SKIP_INTERNAL_TEST
+	return true
+}
+
+proc update_PARAM_VALUE.WB2_ADDR_BITS { PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to update WB2_ADDR_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB2_ADDR_BITS { PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to validate WB2_ADDR_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.WB2_DATA_BITS { PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to update WB2_DATA_BITS when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB2_DATA_BITS { PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to validate WB2_DATA_BITS
+	return true
+}
+
+proc update_PARAM_VALUE.WB_ERROR { PARAM_VALUE.WB_ERROR } {
+	# Procedure called to update WB_ERROR when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.WB_ERROR { PARAM_VALUE.WB_ERROR } {
+	# Procedure called to validate WB_ERROR
+	return true
+}
+
+proc update_PARAM_VALUE.serdes_ratio { PARAM_VALUE.serdes_ratio } {
+	# Procedure called to update serdes_ratio when any of the dependent parameters in the arguments change
+}
+
+proc validate_PARAM_VALUE.serdes_ratio { PARAM_VALUE.serdes_ratio } {
+	# Procedure called to validate serdes_ratio
+	return true
+}
+
+
+proc update_MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD { MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD PARAM_VALUE.CONTROLLER_CLK_PERIOD } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.CONTROLLER_CLK_PERIOD}] ${MODELPARAM_VALUE.CONTROLLER_CLK_PERIOD}
+}
+
+proc update_MODELPARAM_VALUE.DDR3_CLK_PERIOD { MODELPARAM_VALUE.DDR3_CLK_PERIOD PARAM_VALUE.DDR3_CLK_PERIOD } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DDR3_CLK_PERIOD}] ${MODELPARAM_VALUE.DDR3_CLK_PERIOD}
+}
+
+proc update_MODELPARAM_VALUE.ROW_BITS { MODELPARAM_VALUE.ROW_BITS PARAM_VALUE.ROW_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ROW_BITS}] ${MODELPARAM_VALUE.ROW_BITS}
+}
+
+proc update_MODELPARAM_VALUE.COL_BITS { MODELPARAM_VALUE.COL_BITS PARAM_VALUE.COL_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.COL_BITS}] ${MODELPARAM_VALUE.COL_BITS}
+}
+
+proc update_MODELPARAM_VALUE.BA_BITS { MODELPARAM_VALUE.BA_BITS PARAM_VALUE.BA_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.BA_BITS}] ${MODELPARAM_VALUE.BA_BITS}
+}
+
+proc update_MODELPARAM_VALUE.BYTE_LANES { MODELPARAM_VALUE.BYTE_LANES PARAM_VALUE.BYTE_LANES } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.BYTE_LANES}] ${MODELPARAM_VALUE.BYTE_LANES}
+}
+
+proc update_MODELPARAM_VALUE.AXI_ID_WIDTH { MODELPARAM_VALUE.AXI_ID_WIDTH PARAM_VALUE.AXI_ID_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_ID_WIDTH}] ${MODELPARAM_VALUE.AXI_ID_WIDTH}
+}
+
+proc update_MODELPARAM_VALUE.WB2_ADDR_BITS { MODELPARAM_VALUE.WB2_ADDR_BITS PARAM_VALUE.WB2_ADDR_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB2_ADDR_BITS}] ${MODELPARAM_VALUE.WB2_ADDR_BITS}
+}
+
+proc update_MODELPARAM_VALUE.WB2_DATA_BITS { MODELPARAM_VALUE.WB2_DATA_BITS PARAM_VALUE.WB2_DATA_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB2_DATA_BITS}] ${MODELPARAM_VALUE.WB2_DATA_BITS}
+}
+
+proc update_MODELPARAM_VALUE.MICRON_SIM { MODELPARAM_VALUE.MICRON_SIM PARAM_VALUE.MICRON_SIM } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.MICRON_SIM}] ${MODELPARAM_VALUE.MICRON_SIM}
+}
+
+proc update_MODELPARAM_VALUE.ODELAY_SUPPORTED { MODELPARAM_VALUE.ODELAY_SUPPORTED PARAM_VALUE.ODELAY_SUPPORTED } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ODELAY_SUPPORTED}] ${MODELPARAM_VALUE.ODELAY_SUPPORTED}
+}
+
+proc update_MODELPARAM_VALUE.SECOND_WISHBONE { MODELPARAM_VALUE.SECOND_WISHBONE PARAM_VALUE.SECOND_WISHBONE } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.SECOND_WISHBONE}] ${MODELPARAM_VALUE.SECOND_WISHBONE}
+}
+
+proc update_MODELPARAM_VALUE.WB_ERROR { MODELPARAM_VALUE.WB_ERROR PARAM_VALUE.WB_ERROR } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.WB_ERROR}] ${MODELPARAM_VALUE.WB_ERROR}
+}
+
+proc update_MODELPARAM_VALUE.SKIP_INTERNAL_TEST { MODELPARAM_VALUE.SKIP_INTERNAL_TEST PARAM_VALUE.SKIP_INTERNAL_TEST } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.SKIP_INTERNAL_TEST}] ${MODELPARAM_VALUE.SKIP_INTERNAL_TEST}
+}
+
+proc update_MODELPARAM_VALUE.ECC_ENABLE { MODELPARAM_VALUE.ECC_ENABLE PARAM_VALUE.ECC_ENABLE } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.ECC_ENABLE}] ${MODELPARAM_VALUE.ECC_ENABLE}
+}
+
+proc update_MODELPARAM_VALUE.DIC { MODELPARAM_VALUE.DIC PARAM_VALUE.DIC } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DIC}] ${MODELPARAM_VALUE.DIC}
+}
+
+proc update_MODELPARAM_VALUE.RTT_NOM { MODELPARAM_VALUE.RTT_NOM PARAM_VALUE.RTT_NOM } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.RTT_NOM}] ${MODELPARAM_VALUE.RTT_NOM}
+}
+
+proc update_MODELPARAM_VALUE.DQ_BITS { MODELPARAM_VALUE.DQ_BITS PARAM_VALUE.DQ_BITS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.DQ_BITS}] ${MODELPARAM_VALUE.DQ_BITS}
+}
+
+proc update_MODELPARAM_VALUE.serdes_ratio { MODELPARAM_VALUE.serdes_ratio PARAM_VALUE.serdes_ratio } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.serdes_ratio}] ${MODELPARAM_VALUE.serdes_ratio}
+}
+
+proc update_MODELPARAM_VALUE.wb_addr_bits { MODELPARAM_VALUE.wb_addr_bits PARAM_VALUE.wb_addr_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_addr_bits}] ${MODELPARAM_VALUE.wb_addr_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb_data_bits { MODELPARAM_VALUE.wb_data_bits PARAM_VALUE.wb_data_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_data_bits}] ${MODELPARAM_VALUE.wb_data_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb_sel_bits { MODELPARAM_VALUE.wb_sel_bits PARAM_VALUE.wb_sel_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb_sel_bits}] ${MODELPARAM_VALUE.wb_sel_bits}
+}
+
+proc update_MODELPARAM_VALUE.wb2_sel_bits { MODELPARAM_VALUE.wb2_sel_bits PARAM_VALUE.wb2_sel_bits } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.wb2_sel_bits}] ${MODELPARAM_VALUE.wb2_sel_bits}
+}
+
+proc update_MODELPARAM_VALUE.cmd_len { MODELPARAM_VALUE.cmd_len PARAM_VALUE.cmd_len } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.cmd_len}] ${MODELPARAM_VALUE.cmd_len}
+}
+
+proc update_MODELPARAM_VALUE.AXI_LSBS { MODELPARAM_VALUE.AXI_LSBS PARAM_VALUE.AXI_LSBS } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_LSBS}] ${MODELPARAM_VALUE.AXI_LSBS}
+}
+
+proc update_MODELPARAM_VALUE.AXI_ADDR_WIDTH { MODELPARAM_VALUE.AXI_ADDR_WIDTH PARAM_VALUE.AXI_ADDR_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_ADDR_WIDTH}] ${MODELPARAM_VALUE.AXI_ADDR_WIDTH}
+}
+
+proc update_MODELPARAM_VALUE.AXI_DATA_WIDTH { MODELPARAM_VALUE.AXI_DATA_WIDTH PARAM_VALUE.AXI_DATA_WIDTH } {
+	# Procedure called to set VHDL generic/Verilog parameter value(s) based on TCL parameter value
+	set_property value [get_property value ${PARAM_VALUE.AXI_DATA_WIDTH}] ${MODELPARAM_VALUE.AXI_DATA_WIDTH}
+}
+


### PR DESCRIPTION
Vivado can now recognize UberDDR3 as a custom IP block and can now be instantiated on the block diagram. Option to skip the internal test of UberDDR3 calibration is also added to ensure smooth operation with Microblaze (internal test usually takes >2 seconds and that can cause Microblaze to fail boot-up since it cannot access the DDR3 during that time).